### PR TITLE
Diagnostic Handle valid nested YAML

### DIFF
--- a/lib/tap-parser.rb
+++ b/lib/tap-parser.rb
@@ -50,7 +50,7 @@ module TapParser
         return
       end
 
-      /(?<status>ok|not ok)\s*(?<test_number>\d*)\s*-?\s*(?<test_desc>[^#]*)(\s*#\s*(?<test_directive>.*))?/.match(line) do |match|
+      /^(?<status>ok|not ok)\s*(?<test_number>\d*)\s*-?\s*(?<test_desc>[^#]*)(\s*#\s*(?<test_directive>.*))?/.match(line) do |match|
         @tests << Test.new(
           match[:status] == 'ok',
           match[:test_number] ? match[:test_number].to_i : nil,

--- a/lib/tap-parser.rb
+++ b/lib/tap-parser.rb
@@ -15,11 +15,13 @@ module TapParser
     end
 
     def add_diagnostic(line)
+      return if /\s*?\.\.\./.match(line)
       if @diagnostic.empty?
         @diagnostic = line
       else
         @diagnostic = "#{@diagnostic}\n#{line}"
       end
+      @diagnostic = @diagnostic.strip
     end
   end
 
@@ -58,7 +60,7 @@ module TapParser
         return
       end
 
-      /^\s*#?\s*(?<test_diagnostic>.*)$/.match(line) do |match|
+      /^(#\s*)?(?<test_diagnostic>.*)$/.match(line) do |match|
         unless @tests.empty?
           @tests.last.add_diagnostic(match[:test_diagnostic])
         end

--- a/ruby-tap-parser.gemspec
+++ b/ruby-tap-parser.gemspec
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 Gem::Specification.new do |s|
   s.name        = 'ruby-tap-parser'
   s.version     = '0.0.1'

--- a/spec/tap-parser_spec.rb
+++ b/spec/tap-parser_spec.rb
@@ -67,6 +67,24 @@ not ok - yaml format
       expect(YAML.load(parsed.tests.first.diagnostic)['error']['message']).to eq("nested yaml")
 
     end
+
+    it 'handles nested YAML format which may contain a "OK" within' do
+      tap = %Q{TAP version 13
+not ok - yaml format
+  ---
+  error:
+    message: "ok nested yaml"
+  ...
+1..1}
+      parsed = TapParser::TapParser.from_text(tap)
+      expect(parsed.tests.first.diagnostic).to eq(%Q{---
+  error:
+    message: "ok nested yaml"})
+      expect(YAML.load(parsed.tests.first.diagnostic)).to have_key("error")
+      expect(YAML.load(parsed.tests.first.diagnostic)['error']).to have_key("message")
+      expect(YAML.load(parsed.tests.first.diagnostic)['error']['message']).to eq("ok nested yaml")
+
+    end
   end
 
   context 'read_line' do


### PR DESCRIPTION
closes #1 

[TAP Specification 13](http://testanything.org/tap-version-13-specification.html) harness behaviour allows for valid inlined YAML document to extend the diagnostic.

Here a change to the regular expression to handle valid YAML formatted diagnostic data, and gracefully retain standard text support. 
